### PR TITLE
Clarify licensing info for src/macro.rs and src/curve/montgomery/montgomery.rs

### DIFF
--- a/src/curve/montgomery/montgomery.rs
+++ b/src/curve/montgomery/montgomery.rs
@@ -1,7 +1,8 @@
 // The original file was a part of curve25519-dalek.
 // Copyright (c) 2016-2019 Isis Lovecruft, Henry de Valence
 // Copyright (c) 2020 Kevaundray Wedderburn
-// See LICENSE for licensing information.
+// Licensed under BSD-3-Clause license
+// (See https://github.com/dalek-cryptography/curve25519-dalek/blob/main/curve25519-dalek/LICENSE for more information)
 //
 // Authors:
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,7 +3,8 @@
 // This file is part of curve25519-dalek.
 // Copyright (c) 2016-2021 isis agora lovecruft
 // Copyright (c) 2016-2019 Henry de Valence
-// See LICENSE for licensing information.
+// Licensed under BSD-3-Clause license
+// (See https://github.com/dalek-cryptography/curve25519-dalek/blob/main/curve25519-dalek/LICENSE for more information)
 //
 // Authors:
 // - isis agora lovecruft <isis@patternsinthevoid.net>


### PR DESCRIPTION
No LICENSE file exists in this repository, but the two files are indeed licensed under the terms of the BSD-3-Clause license.

This change clarifies the licensing information so that it is internally comprehensible, while providing a clearer link to the original source of the two files.